### PR TITLE
Add GitHub Action for deploying to PyPI

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
A deploy to PyPI will be made when a tag is pushed that starts with a "v" (eg "v0.1.0").

TODO:
- [x] Add env-vars for PyPI
- [x] Register package name on PyPI