### PR TITLE
Remove upper limit on Python version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for mypy-json-report
 
+## Upcoming
+
+- Remove upper limit on Python version. This fixes compatibility with newly created Poetry projects.
+
 ## v0.1.2 [2022-01-17]
 
 - Trial releasing with GitHub actions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 Source = "https://github.com/memrise/mypy-json-report"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.11"
+python = ">=3.7"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.24.5"


### PR DESCRIPTION
This makes the library easier to install on projects managed by Poetry,
which would otherwise fail with an error like:
```
SolverProblemError

The current project's Python requirement (>=3.10,<4.0) is not compatible with some of the required packages Python requirement:
  - mypy-json-report requires Python >=3.7,<3.11, so it will not be satisfied for Python >=3.11,<4.0

Because mypy-json-report (0.1.2) requires Python >=3.7,<3.11
 and no versions of mypy-json-report match >0.1.2,<0.2.0, mypy-json-report is forbidden.
So, because $PROJECT_NAME depends on mypy-json-report (^0.1.2), version solving failed.
```