### PR TITLE
Run pre-commit as a separate workflow in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,25 @@
+---
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Pre-commit
+        uses: pre-commit/action@v3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ isolated_build = True
 
 [gh-actions]
 python =
-    3.7: py37,precommit,mypy
+    3.7: py37,mypy
     3.8: py38
     3.9: py39
     3.10: py310
@@ -28,12 +28,6 @@ deps =
     pytest~=6.2.5
 
 commands = python -m pytest {posargs:tests} -vv
-
-
-[testenv:precommit]
-deps =
-    pre-commit~=2.16.0
-commands = pre-commit run --all-files --show-diff-on-failure
 
 
 [testenv:mypy]


### PR DESCRIPTION
This makes the Tox configuration simpler to work with and means pre-commit
always will run even though tests fail on Python 3.7.