### PR TITLE
Use Poetry to manage dependencies in the release workflow

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -7,30 +7,30 @@ on:
       - v*
 
 jobs:
-  deploy:
+  release:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Poetry
+        run: pipx install poetry
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
+          cache: poetry
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel poetry
+      - name: Install dependencies
+        run: poetry install
 
-      - name: Build python package
-        run: |
-          poetry build
+      - name: Build package
+        run: poetry build
 
       - name: Upload to PyPI
         env:
           POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
           POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          poetry publish
+        run: poetry publish


### PR DESCRIPTION
This also fixes some other minor things:

1. The name of the job is changed from "deploy" to "release".
2. The multi-line command syntax is removed since we only run one command per step.