### PR TITLE
Switch to released version of Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11-dev"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - name: Checkout the code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for mypy-json-report
 
+## Unreleased
+
+- Use GA version of Python 3.11 in test matrix.
+
 ## v0.1.3 [2022-09-07]
 
 - Removed upper bound for Python compatibility


### PR DESCRIPTION
Python 3.11 has now been released so we can use the GA version of it.