### PR TITLE
Add totals report

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+# This file is not used by anything in the repo.
+# It is here as a convenience to developers who use flake8 locally.
+
+[flake8]
+ignore =
+    E203  # whitespace before ':' - conflicts with black
+    E501  # line too long - black takes care of this for us
+    W503  # line break before binary operator - this is what black does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `help` command to print out usage information.
+- Add `totals` command to quantify the errors recorded in a file.
 - Use GA version of Python 3.11 in test matrix.
 
 ## v0.1.3 [2022-09-07]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `help` command to print out usage information.
 - Use GA version of Python 3.11 in test matrix.
 
 ## v0.1.3 [2022-09-07]

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -16,8 +16,7 @@ import json
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Counter as CounterType
-from typing import Dict, Iterator
+from typing import Counter as CounterType, Dict, Iterator
 
 
 def main() -> None:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -21,7 +21,7 @@ from typing import Counter as CounterType, Dict, Iterator
 
 def main() -> None:
     args = sys.argv[1:]
-    if args == []:
+    if args in ([], ["errors"]):
         report_errors()
     else:
         print("Unexpected command:", args)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -20,6 +20,10 @@ from typing import Counter as CounterType, Dict, Iterator
 
 
 def main() -> None:
+    report_errors()
+
+
+def report_errors() -> None:
     errors = produce_errors_report(sys.stdin)
     error_json = json.dumps(errors, sort_keys=True, indent=2)
     print(error_json)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -20,7 +20,12 @@ from typing import Counter as CounterType, Dict, Iterator
 
 
 def main() -> None:
-    report_errors()
+    args = sys.argv[1:]
+    if args == []:
+        report_errors()
+    else:
+        print("Unexpected command:", args)
+        exit(1)
 
 
 def report_errors() -> None:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -21,7 +21,8 @@ from typing import Counter as CounterType, Dict, Iterator
 
 def main() -> None:
     errors = produce_errors_report(sys.stdin)
-    print(errors)
+    error_json = json.dumps(errors, sort_keys=True, indent=2)
+    print(error_json)
 
 
 @dataclass(frozen=True)
@@ -30,12 +31,12 @@ class MypyError:
     message: str
 
 
-def produce_errors_report(input_lines: Iterator[str]) -> str:
+def produce_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]:
     """Given lines from mypy's output, return a JSON summary of error frequencies by file."""
     errors = _extract_errors(input_lines)
     error_frequencies = _count_errors(errors)
     structured_errors = _structure_errors(error_frequencies)
-    return json.dumps(structured_errors, sort_keys=True, indent=2)
+    return structured_errors
 
 
 def _extract_errors(lines: Iterator[str]) -> Iterator[MypyError]:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -23,9 +23,33 @@ def main() -> None:
     args = sys.argv[1:]
     if args in ([], ["errors"]):
         report_errors()
+        return
+
+    command, *options = args
+    if command in ("help", "-h", "--help"):
+        help()
     else:
         print("Unexpected command:", args)
+        help()
         exit(1)
+
+
+_help_text = """
+Usage: mypy-json-report [COMMAND]
+
+  Generate a JSON report from your mypy output.
+
+COMMAND:
+    errors (default)    Generate a report from mypy's output.
+                        Mypy's output is accepted from stdin.
+                        The report will be sent to stdout.
+
+    help, -h, --help    Prints this help.
+"""
+
+
+def help() -> None:
+    print(_help_text)
 
 
 def report_errors() -> None:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -20,7 +20,8 @@ from typing import Counter as CounterType, Dict, Iterator
 
 
 def main() -> None:
-    print(produce_errors_report(sys.stdin))
+    errors = produce_errors_report(sys.stdin)
+    print(errors)
 
 
 @dataclass(frozen=True)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -29,7 +29,7 @@ def main() -> None:
     if command in ("help", "-h", "--help"):
         help()
     else:
-        print("Unexpected command:", args)
+        print("Unexpected command:", command)
         help()
         exit(1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ mypy-json-report = "mypy_json_report:main"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+combine_as_imports = true
+known_first_party = ["mypy_json_report"]
+lines_after_imports = 2
+profile = "black"

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -3,6 +3,7 @@ from io import StringIO
 
 from mypy_json_report import produce_errors_report
 
+
 EXAMPLE_MYPY_STDOUT = """\
 mypy_json_report.py:8: error: Function is missing a return type annotation
 mypy_json_report.py:8: note: Use "-> None" if function does not return a value

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,4 +1,3 @@
-import json
 from io import StringIO
 
 from mypy_json_report import produce_errors_report
@@ -14,7 +13,7 @@ Found 2 errors in 1 file (checked 3 source files)"""
 def test_report() -> None:
     report = produce_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
 
-    assert json.loads(report) == {
+    assert report == {
         "mypy_json_report.py": {
             'Call to untyped function "main" in typed context': 1,
             "Function is missing a return type annotation": 1,

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from mypy_json_report import produce_errors_report
+from mypy_json_report import produce_errors_report, produce_errors_summary
 
 
 EXAMPLE_MYPY_STDOUT = """\
@@ -19,3 +19,20 @@ def test_errors_report() -> None:
             "Function is missing a return type annotation": 1,
         }
     }
+
+
+def test_errors_summary() -> None:
+    errors = {
+        "file.py": {
+            'Call to untyped function "main" in typed context': 1,
+            "Function is missing a return type annotation": 2,
+        },
+        "another_file.py": {
+            'Call to untyped function "test" in typed context': 1,
+            "Function is missing a return type annotation": 1,
+        },
+    }
+
+    totals = produce_errors_summary(errors)
+
+    assert totals == {"files_with_errors": 2, "total_errors": 5}

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -10,7 +10,7 @@ mypy_json_report.py:68: error: Call to untyped function "main" in typed context
 Found 2 errors in 1 file (checked 3 source files)"""
 
 
-def test_report() -> None:
+def test_errors_report() -> None:
     report = produce_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
 
     assert report == {


### PR DESCRIPTION
This adds:
- New isort and flake8 configs.
- Very basic arg parsing. (More on this below.)
- A `help` command.
- A `totals` command. This produces a basic summary of a previously created JSON report file.

This lacks (todo):
- [ ] Docstrings
- [ ] A command to print the summary of a report file over time.

**Question:** Is it time to break this into modules?
**Question:** Would you prefer me to replace this with Typer (or similar)?