### PR TITLE
Expanded linting (isort and flake8 configs)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+# This file is not used by anything in the repo.
+# It is here as a convenience to developers who use flake8 locally.
+
+[flake8]
+ignore =
+    E203  # whitespace before ':' - conflicts with black
+    E501  # line too long - black takes care of this for us
+    W503  # line break before binary operator - this is what black does

--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,11 @@
 
 [flake8]
 ignore =
-    E203  # whitespace before ':' - conflicts with black
-    E501  # line too long - black takes care of this for us
-    W503  # line break before binary operator - this is what black does
+    # whitespace before ':' - conflicts with black
+    E203
+
+    # line too long - black takes care of this for us
+    E501
+
+    # line break before binary operator - this is what black does
+    W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -16,8 +16,7 @@ import json
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Counter as CounterType
-from typing import Dict, Iterator
+from typing import Counter as CounterType, Dict, Iterator
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ mypy-json-report = "mypy_json_report:main"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+combine_as_imports = true
+known_first_party = ["mypy_json_report"]
+lines_after_imports = 2
+profile = "black"

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -3,6 +3,7 @@ from io import StringIO
 
 from mypy_json_report import produce_errors_report
 
+
 EXAMPLE_MYPY_STDOUT = """\
 mypy_json_report.py:8: error: Function is missing a return type annotation
 mypy_json_report.py:8: note: Use "-> None" if function does not return a value


### PR DESCRIPTION
This adds an isort and flake8 config.

This has been spun out of #18 to reduce the footprint of that PR.