### PR TITLE
Move parsing into `parse` subcommand (introduce argparse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- *Action required:* Move existing behaviour under "parse" subcommand.
+  Invocations of `mypy-json-report` should now be replaced with `mypy-json-report parse`.
 - Use GA version of Python 3.11 in test matrix.
 
 ## v0.1.3 [2022-09-07]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - *Action required:* Move existing behaviour under "parse" subcommand.
   Invocations of `mypy-json-report` should now be replaced with `mypy-json-report parse`.
+- Add `parse --indentation` flag to grant control over how much indentation is used in the JSON report.
 - Use GA version of Python 3.11 in test matrix.
 
 ## v0.1.3 [2022-09-07]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pipe the output of mypy through the `mypy-json-report` CLI app.
 Store the output to a file, and commit it to your git repo.
 
 ```
-mypy . --strict | mypy-json-report > known-mypy-errors.json
+mypy . --strict | mypy-json-report parse > known-mypy-errors.json
 git add known-mypy-errors.json
 git commit -m "Add mypy errors lockfile"
 ```
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run mypy
         run: |
-          mypy . --strict | mypy-json-report > known-mypy-errors.json
+          mypy . --strict | mypy-json-report parse > known-mypy-errors.json
 
       - name: Check for mypy changes
         run: |

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -24,7 +24,8 @@ def main() -> None:
 
 
 def report_errors() -> None:
-    print(produce_errors_report(sys.stdin))
+    errors = produce_errors_report(sys.stdin)
+    print(errors)
 
 
 @dataclass(frozen=True)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -48,14 +48,14 @@ def main() -> None:
     parsed.func(parsed)
 
 
-def _parse_command(args: object) -> None:
+def _parse_command(args: argparse.Namespace) -> None:
     """Handle the `parse` command."""
     errors = parse_errors_report(sys.stdin)
     error_json = json.dumps(errors, sort_keys=True, indent=2)
     print(error_json)
 
 
-def _no_command(args: object) -> None:
+def _no_command(args: argparse.Namespace) -> None:
     """
     Handle the lack of an explicit command.
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -43,8 +43,7 @@ def main() -> None:
 
     parse_parser.set_defaults(func=_parse_command)
 
-    args = sys.argv[1:]
-    parsed = parser.parse_args(args)
+    parsed = parser.parse_args()
     parsed.func(parsed)
 
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -40,6 +40,13 @@ def main() -> None:
     parse_parser = subparsers.add_parser(
         "parse", help="Transform Mypy output into JSON."
     )
+    parse_parser.add_argument(
+        "-i",
+        "--indentation",
+        type=int,
+        default=2,
+        help="Number of spaces to indent JSON output.",
+    )
 
     parse_parser.set_defaults(func=_parse_command)
 
@@ -50,7 +57,7 @@ def main() -> None:
 def _parse_command(args: argparse.Namespace) -> None:
     """Handle the `parse` command."""
     errors = parse_errors_report(sys.stdin)
-    error_json = json.dumps(errors, sort_keys=True, indent=2)
+    error_json = json.dumps(errors, sort_keys=True, indent=args.indentation)
     print(error_json)
 
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -25,7 +25,8 @@ def main() -> None:
 
 def report_errors() -> None:
     errors = produce_errors_report(sys.stdin)
-    print(errors)
+    error_json = json.dumps(errors, sort_keys=True, indent=2)
+    print(error_json)
 
 
 @dataclass(frozen=True)
@@ -34,12 +35,12 @@ class MypyError:
     message: str
 
 
-def produce_errors_report(input_lines: Iterator[str]) -> str:
+def produce_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]:
     """Given lines from mypy's output, return a JSON summary of error frequencies by file."""
     errors = _extract_errors(input_lines)
     error_frequencies = _count_errors(errors)
     structured_errors = _structure_errors(error_frequencies)
-    return json.dumps(structured_errors, sort_keys=True, indent=2)
+    return structured_errors
 
 
 def _extract_errors(lines: Iterator[str]) -> Iterator[MypyError]:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -20,6 +20,10 @@ from typing import Counter as CounterType, Dict, Iterator
 
 
 def main() -> None:
+    report_errors()
+
+
+def report_errors() -> None:
     print(produce_errors_report(sys.stdin))
 
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -72,7 +72,7 @@ class MypyError:
 
 
 def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]:
-    """Given lines from mypy's output, return a JSON summary of error frequencies by file."""
+    """Given lines from mypy's output, return a summary of error frequencies by file."""
     errors = _extract_errors(input_lines)
     error_frequencies = _count_errors(errors)
     structured_errors = _structure_errors(error_frequencies)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -24,7 +24,7 @@ def main() -> None:
 
 
 def report_errors() -> None:
-    errors = produce_errors_report(sys.stdin)
+    errors = parse_errors_report(sys.stdin)
     error_json = json.dumps(errors, sort_keys=True, indent=2)
     print(error_json)
 
@@ -35,7 +35,7 @@ class MypyError:
     message: str
 
 
-def produce_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]:
+def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]:
     """Given lines from mypy's output, return a JSON summary of error frequencies by file."""
     errors = _extract_errors(input_lines)
     error_frequencies = _count_errors(errors)

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from mypy_json_report import produce_errors_report
+from mypy_json_report import parse_errors_report
 
 
 EXAMPLE_MYPY_STDOUT = """\
@@ -10,8 +10,8 @@ mypy_json_report.py:68: error: Call to untyped function "main" in typed context
 Found 2 errors in 1 file (checked 3 source files)"""
 
 
-def test_report() -> None:
-    report = produce_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
+def test_parse_errors_report() -> None:
+    report = parse_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
 
     assert report == {
         "mypy_json_report.py": {

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,4 +1,3 @@
-import json
 from io import StringIO
 
 from mypy_json_report import produce_errors_report
@@ -14,7 +13,7 @@ Found 2 errors in 1 file (checked 3 source files)"""
 def test_report() -> None:
     report = produce_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
 
-    assert json.loads(report) == {
+    assert report == {
         "mypy_json_report.py": {
             'Call to untyped function "main" in typed context': 1,
             "Function is missing a return type annotation": 1,

--- a/tox.ini
+++ b/tox.ini
@@ -39,5 +39,5 @@ allowlist_externals =
 commands_pre =
     poetry install
 commands =
-    poetry run bash -c "mypy . --strict | mypy-json-report > known-mypy-errors.json"
+    poetry run bash -c "mypy . --strict | mypy-json-report parse > known-mypy-errors.json"
     git diff --exit-code known-mypy-errors.json


### PR DESCRIPTION
We intend to add more functionality to this tool, so it no longer makes sense to have the error parsing functionality at the top level when calling the script.

This change introduces (and requires) a new `parse` subcommand, under which the existing parsing function is moved. This change is **backwards incompatible**.

Because we're using argparse to do this, we also get a new "--help" flag on the command.

We also add a new `--indentation` flag to the `parse` subcommand which grants control over the indentation in the JSON output.

This is spun out of https://github.com/Memrise/mypy-json-report/pull/18, which will introduce a new command.