### PR TITLE
Add missing Python 3.11 trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
This package metadata is used by tools such as PyPI for classifying packages.

We already have Python 3.11 in the test matrix, so we should have it in this list too.