### PR TITLE
Add flag to output directly to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - *Action required:* Move existing behaviour under "parse" subcommand.
   Invocations of `mypy-json-report` should now be replaced with `mypy-json-report parse`.
 - Add `parse --indentation` flag to grant control over how much indentation is used in the JSON report.
+- Add `parse --output-file` flag to allow sending report direct to a file rather than STDOUT.
 - Use GA version of Python 3.11 in test matrix.
 
 ## v0.1.3 [2022-09-07]

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -52,7 +52,7 @@ def main() -> None:
         "-o",
         "--output-file",
         type=pathlib.Path,
-        help="The file to write the JSON report to. If omitted, the report will write to STDOUT.",
+        help="The file to write the JSON report to. If omitted, the report will be written to STDOUT.",
     )
 
     parse_parser.set_defaults(func=_parse_command)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -15,6 +15,7 @@
 import argparse
 import enum
 import json
+import pathlib
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -47,6 +48,12 @@ def main() -> None:
         default=2,
         help="Number of spaces to indent JSON output.",
     )
+    parse_parser.add_argument(
+        "-o",
+        "--output-file",
+        type=pathlib.Path,
+        help="The file to write the JSON report to. If omitted, the report will write to STDOUT.",
+    )
 
     parse_parser.set_defaults(func=_parse_command)
 
@@ -58,7 +65,10 @@ def _parse_command(args: argparse.Namespace) -> None:
     """Handle the `parse` command."""
     errors = parse_errors_report(sys.stdin)
     error_json = json.dumps(errors, sort_keys=True, indent=args.indentation)
-    print(error_json)
+    if args.output_file:
+        args.output_file.write_text(error_json + "\n")
+    else:
+        print(error_json)
 
 
 def _no_command(args: argparse.Namespace) -> None:


### PR DESCRIPTION
In some cases this is nicer than outputting to STDOUT, though that is still the default.

This will be crucial to an upcoming PR, where we want to read from the ratchet file before writing to it, which would have been a real pain with pipes.