### PR TITLE
Compare against old JSON report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   Invocations of `mypy-json-report` should now be replaced with `mypy-json-report parse`.
 - Add `parse --indentation` flag to grant control over how much indentation is used in the JSON report.
 - Add `parse --output-file` flag to allow sending report direct to a file rather than STDOUT.
+- Add `parse --diff-old-report` flag for a report of the difference since the last JSON report.
 - Use GA version of Python 3.11 in test matrix.
 
 ## v0.1.3 [2022-09-07]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and repeated errors are counted.
 
 ## Ratchet file
 
-The `--diff-old-report FILNAME` flag serves two purposes.
+The `--diff-old-report FILENAME` flag serves two purposes.
 
 1. It prints new (and adjacent, and similar) errors to STDERR.
    This is useful for seeing what errors need to be fixed before committing.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Pipe the output of mypy through the `mypy-json-report` CLI app.
 Store the output to a file, and commit it to your git repo.
 
 ```
-mypy . --strict | mypy-json-report parse > known-mypy-errors.json
-git add known-mypy-errors.json
-git commit -m "Add mypy errors lockfile"
+mypy . --strict | mypy-json-report parse --output-file mypy-ratchet.json
+git add mypy-ratchet.json
+git commit -m "Add mypy errors ratchet file"
 ```
 
 Now you have a snapshot of the mypy errors in your project.
@@ -50,6 +50,17 @@ To reduce churn,
 the line on which the errors occur is removed
 and repeated errors are counted.
 
+
+## Ratchet file
+
+The `--diff-old-report FILNAME` flag serves two purposes.
+
+1. It prints new (and adjacent, and similar) errors to STDERR.
+   This is useful for seeing what errors need to be fixed before committing.
+
+1. It will error when the ratchet file doesn't match the new report.
+   This is helpful for catching uncommitted changes in CI.
+
 ## Example usage
 
 You could create a GitHub Action to catch regressions (or improvements).
@@ -80,9 +91,5 @@ jobs:
 
       - name: Run mypy
         run: |
-          mypy . --strict | mypy-json-report parse > known-mypy-errors.json
-
-      - name: Check for mypy changes
-        run: |
-          git diff --exit-code
+          mypy . --strict | mypy-json-report parse --diff-old-report mypy-ratchet.json --output-file mypy-ratchet.json
 ```

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -97,9 +97,7 @@ def main() -> None:
 ErrorSummary = Dict[str, Dict[str, int]]
 
 
-def _load_json_file(filepath: Optional[pathlib.Path]) -> Optional[ErrorSummary]:
-    if not filepath:
-        return None
+def _load_json_file(filepath: pathlib.Path) -> ErrorSummary:
     with filepath.open() as json_file:
         return cast(ErrorSummary, json.load(json_file))
 
@@ -116,8 +114,8 @@ def _parse_command(args: argparse.Namespace) -> None:
 
     # If we have access to an old report, add the ChangeTracker processor.
     tracker = None
-    old_report = _load_json_file(args.diff_old_report)
-    if old_report is not None:
+    if args.diff_old_report is not None:
+        old_report = _load_json_file(args.diff_old_report)
         tracker = ChangeTracker(old_report)
         processors.append(tracker)
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -25,6 +25,8 @@ from typing import Counter as CounterType, Dict, Iterator, List, Optional, Tuple
 
 class ErrorCodes(enum.IntEnum):
     DEPRECATED = 1
+    # Argparse returns 2 when bad args are passed.
+    ERROR_DIFF = 3
 
 
 def main() -> None:
@@ -115,6 +117,9 @@ def _parse_command(args: argparse.Namespace) -> None:
     print(f"Fixed errors: {diff.num_fixed_errors}", file=sys.stderr)
     print(f"New errors: {diff.num_new_errors}", file=sys.stderr)
     print(f"Total errors: {diff.total_errors}", file=sys.stderr)
+
+    if diff.num_new_errors or diff.num_fixed_errors:
+        exit(ErrorCodes.ERROR_DIFF)
 
 
 def _no_command(args: argparse.Namespace) -> None:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -112,8 +112,8 @@ class ErrorCounter:
         Given lines from mypy's output, update the summary of error frequencies.
         """
         messages = _extract_messages(input_lines)
-        for error in messages:
-            self.grouped_errors[error.filename][error.message] += 1
+        for message in messages:
+            self.grouped_errors[message.filename][message.message] += 1
 
 
 def _extract_messages(lines: Iterator[str]) -> Iterator[MypyMessage]:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -90,24 +90,26 @@ class MypyMessage:
 
 
 class ErrorCounter:
-    """Produces a summary of errors in a Mypy report."""
+    """
+    Produces a summary of errors in a Mypy report.
+
+    The structure of grouped_errors looks like this once processing is complete:
+
+        {
+            "module/filename.py": {
+                "Mypy error message": 42,
+                "Another error message": 19,
+                ...
+            },
+            ...
+        }
+    """
 
     grouped_errors: Dict[str, Dict[str, int]]
 
     def parse_errors_report(self, input_lines: Iterator[str]) -> None:
         """
-        Given lines from mypy's output, return a summary of error frequencies by file.
-
-        The resulting structure looks like this:
-
-            {
-                "module/filename.py": {
-                    "Mypy error message": 42,
-                    "Another error message": 19,
-                    ...
-                },
-                ...
-            }
+        Given lines from mypy's output, update the summary of error frequencies.
         """
         messages = _extract_messages(input_lines)
         self.grouped_errors = defaultdict(Counter)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -105,14 +105,14 @@ class ErrorCounter:
         }
     """
 
-    grouped_errors: Dict[str, Dict[str, int]]
+    def __init__(self) -> None:
+        self.grouped_errors: Dict[str, Dict[str, int]] = defaultdict(Counter)
 
     def parse_errors_report(self, input_lines: Iterator[str]) -> None:
         """
         Given lines from mypy's output, update the summary of error frequencies.
         """
         messages = _extract_messages(input_lines)
-        self.grouped_errors = defaultdict(Counter)
         for error in messages:
             self.grouped_errors[error.filename][error.message] += 1
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -94,11 +94,11 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
     The resulting structure looks like this:
 
         {
-            "module/filename.py": [
+            "module/filename.py": {
                 "Mypy error message": 42,
                 "Another error message": 19,
                 ...
-            ],
+            },
             ...
         }
     """

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -125,11 +125,11 @@ def _parse_command(args: argparse.Namespace) -> None:
 
     # Print the JSON report to file or STDOUT.
     errors = error_counter.grouped_errors
-    error_json = json.dumps(errors, sort_keys=True, indent=args.indentation)
+    error_json = json.dumps(errors, sort_keys=True, indent=args.indentation) + "\n"
     if args.output_file:
-        args.output_file.write_text(error_json + "\n")
+        args.output_file.write_text(error_json)
     else:
-        print(error_json)
+        sys.stdout.write(error_json)
 
     if tracker is None:
         return

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -165,7 +165,7 @@ class MypyMessage:
             line_number=int(line_number),
             message=message,
             message_type=message_type,
-            raw=line,
+            raw=line.rstrip(),
         )
 
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -110,10 +110,9 @@ def _parse_command(args: argparse.Namespace) -> None:
         report_writer = args.output_file.write_text
     else:
         report_writer = sys.stdout.write
-    error_counter = ErrorCounter(
-        report_writer=report_writer, indentation=args.indentation
-    )
-    processors: List[Union[ErrorCounter, ChangeTracker]] = [error_counter]
+    processors: List[Union[ErrorCounter, ChangeTracker]] = [
+        ErrorCounter(report_writer=report_writer, indentation=args.indentation)
+    ]
 
     # If we have access to an old report, add the ChangeTracker processor.
     tracker = None

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -88,7 +88,20 @@ class MypyError:
 
 
 def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]:
-    """Given lines from mypy's output, return a summary of error frequencies by file."""
+    """
+    Given lines from mypy's output, return a summary of error frequencies by file.
+
+    The resulting structure looks like this:
+
+        {
+            "module/filename.py": [
+                "Mypy error message": 42,
+                "Another error message": 19,
+                ...
+            ],
+            ...
+        }
+    """
     errors = _extract_errors(input_lines)
     error_frequencies = _count_errors(errors)
     structured_errors = _structure_errors(error_frequencies)
@@ -117,17 +130,6 @@ def _count_errors(errors: Iterator[MypyError]) -> CounterType[MypyError]:
 def _structure_errors(errors: CounterType[MypyError]) -> Dict[str, Dict[str, int]]:
     """
     Produce a structure to hold the mypy errors.
-
-    The resulting structure looks like this:
-
-        {
-            "module/filename.py": [
-                "Mypy error message": 42,
-                "Another error message": 19,
-                ...
-            ],
-            ...
-        }
     """
     grouped_errors: Dict[str, Dict[str, int]] = defaultdict(dict)
     for error, frequency in errors.items():

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -82,7 +82,7 @@ def _no_command(args: argparse.Namespace) -> None:
 
 
 @dataclass(frozen=True)
-class MypyError:
+class MypyMessage:
     filename: str
     message: str
 
@@ -103,7 +103,7 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
         }
     """
     messages = _extract_messages(input_lines)
-    error_frequencies: CounterType[MypyError] = Counter(messages)
+    error_frequencies: CounterType[MypyMessage] = Counter(messages)
     grouped_errors: Dict[str, Dict[str, int]] = defaultdict(dict)
     for error, frequency in error_frequencies.items():
         grouped_errors[error.filename][error.message] = frequency
@@ -111,8 +111,8 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
     return dict(grouped_errors)
 
 
-def _extract_messages(lines: Iterator[str]) -> Iterator[MypyError]:
-    """Given lines from mypy's output, yield a series of MypyError objects."""
+def _extract_messages(lines: Iterator[str]) -> Iterator[MypyMessage]:
+    """Given lines from mypy's output, yield a series of MypyMessage objects."""
     for line in lines:
         try:
             location, message_type, message = line.strip().split(": ", 2)
@@ -122,7 +122,7 @@ def _extract_messages(lines: Iterator[str]) -> Iterator[MypyError]:
             continue
         if message_type != "error":
             continue
-        yield MypyError(filename=location.split(":")[0], message=message)
+        yield MypyMessage(filename=location.split(":")[0], message=message)
 
 
 if __name__ == "__main__":

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -103,7 +103,7 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
         }
     """
     errors = _extract_errors(input_lines)
-    error_frequencies = _count_errors(errors)
+    error_frequencies: CounterType[MypyError] = Counter(errors)
     structured_errors = _structure_errors(error_frequencies)
     return structured_errors
 
@@ -120,11 +120,6 @@ def _extract_errors(lines: Iterator[str]) -> Iterator[MypyError]:
         if message_type != "error":
             continue
         yield MypyError(filename=location.split(":")[0], message=message)
-
-
-def _count_errors(errors: Iterator[MypyError]) -> CounterType[MypyError]:
-    """Count and deduplicate MypyError objects."""
-    return Counter(errors)
 
 
 def _structure_errors(errors: CounterType[MypyError]) -> Dict[str, Dict[str, int]]:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -104,8 +104,11 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
     """
     errors = _extract_errors(input_lines)
     error_frequencies: CounterType[MypyError] = Counter(errors)
-    structured_errors = _structure_errors(error_frequencies)
-    return structured_errors
+    grouped_errors: Dict[str, Dict[str, int]] = defaultdict(dict)
+    for error, frequency in error_frequencies.items():
+        grouped_errors[error.filename][error.message] = frequency
+
+    return dict(grouped_errors)
 
 
 def _extract_errors(lines: Iterator[str]) -> Iterator[MypyError]:
@@ -120,17 +123,6 @@ def _extract_errors(lines: Iterator[str]) -> Iterator[MypyError]:
         if message_type != "error":
             continue
         yield MypyError(filename=location.split(":")[0], message=message)
-
-
-def _structure_errors(errors: CounterType[MypyError]) -> Dict[str, Dict[str, int]]:
-    """
-    Produce a structure to hold the mypy errors.
-    """
-    grouped_errors: Dict[str, Dict[str, int]] = defaultdict(dict)
-    for error, frequency in errors.items():
-        grouped_errors[error.filename][error.message] = frequency
-
-    return dict(grouped_errors)
 
 
 if __name__ == "__main__":

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -38,9 +38,10 @@ from typing import (
 
 
 class ErrorCodes(enum.IntEnum):
-    DEPRECATED = 1
+    # 1 is returned when an uncaught exception is raised.
     # Argparse returns 2 when bad args are passed.
     ERROR_DIFF = 3
+    DEPRECATED = 4
 
 
 def main() -> None:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -93,6 +93,9 @@ class MypyMessage:
     message_type: str
 
 
+ErrorSummary = Dict[str, Dict[str, int]]
+
+
 class ErrorCounter:
     """
     Produces a summary of errors in a Mypy report.
@@ -110,7 +113,7 @@ class ErrorCounter:
     """
 
     def __init__(self) -> None:
-        self.grouped_errors: Dict[str, Dict[str, int]] = defaultdict(Counter)
+        self.grouped_errors: ErrorSummary = defaultdict(Counter)
 
     def process_message(self, message: MypyMessage) -> None:
         if message.message_type != "error":

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -264,8 +264,7 @@ class ChangeTracker:
         self.num_new_errors += sum(new_errors_in_file.values())
         for new_error in new_errors_in_file:
             for line_number in line_numbers_by_error[new_error]:
-                for raw_line in messages_by_line_number[line_number]:
-                    self.error_lines.append(raw_line)
+                self.error_lines.extend(messages_by_line_number[line_number])
 
         # Find counts for errors resolved.
         resolved_errors = old_report_counter - error_frequencies

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -103,10 +103,9 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
         }
     """
     messages = _extract_messages(input_lines)
-    error_frequencies: CounterType[MypyMessage] = Counter(messages)
-    grouped_errors: Dict[str, Dict[str, int]] = defaultdict(dict)
-    for error, frequency in error_frequencies.items():
-        grouped_errors[error.filename][error.message] = frequency
+    grouped_errors: Dict[str, CounterType[str]] = defaultdict(Counter)
+    for error in messages:
+        grouped_errors[error.filename][error.message] += 1
 
     return dict(grouped_errors)
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -213,11 +213,10 @@ class ErrorCounter:
         if counted_errors:
             self.grouped_errors[filename] = counted_errors
 
-    def write_report(self) -> Optional[ErrorCodes]:
+    def write_report(self) -> None:
         errors = self.grouped_errors
         error_json = json.dumps(errors, sort_keys=True, indent=self.indentation) + "\n"
         self.report_writer(error_json)
-        return None
 
 
 @dataclass(frozen=True)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -87,6 +87,7 @@ def _no_command(args: argparse.Namespace) -> None:
 class MypyMessage:
     filename: str
     message: str
+    message_type: str
 
 
 class ErrorCounter:
@@ -133,7 +134,9 @@ def extract_message(line: str) -> Optional[MypyMessage]:
         return None
     if message_type != "error":
         return None
-    return MypyMessage(filename=location.split(":")[0], message=message)
+    return MypyMessage(
+        filename=location.split(":")[0], message=message, message_type=message_type
+    )
 
 
 if __name__ == "__main__":

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -215,8 +215,8 @@ class ErrorCounter:
 
     def write_report(self) -> None:
         errors = self.grouped_errors
-        error_json = json.dumps(errors, sort_keys=True, indent=self.indentation) + "\n"
-        self.report_writer(error_json)
+        error_json = json.dumps(errors, sort_keys=True, indent=self.indentation)
+        self.report_writer(error_json + "\n")
 
 
 @dataclass(frozen=True)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -97,7 +97,7 @@ def main() -> None:
 ErrorSummary = Dict[str, Dict[str, int]]
 
 
-def _load_json_file(filepath: pathlib.Path) -> ErrorSummary:
+def _load_json_file(filepath: pathlib.Path) -> Dict[str, Any]:
     with filepath.open() as json_file:
         return cast(ErrorSummary, json.load(json_file))
 
@@ -115,7 +115,7 @@ def _parse_command(args: argparse.Namespace) -> None:
     # If we have access to an old report, add the ChangeTracker processor.
     tracker = None
     if args.diff_old_report is not None:
-        old_report = _load_json_file(args.diff_old_report)
+        old_report = cast(ErrorSummary, _load_json_file(args.diff_old_report))
         tracker = ChangeTracker(old_report)
         processors.append(tracker)
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -286,12 +286,13 @@ class ChangeTracker:
         )
 
     def write_report(self) -> Optional[ErrorCodes]:
+        write = sys.stderr.write
         diff = self.diff_report()
         new_errors = "\n".join(diff.error_lines)
-        print(new_errors, file=sys.stderr)
-        print(f"Fixed errors: {diff.num_fixed_errors}", file=sys.stderr)
-        print(f"New errors: {diff.num_new_errors}", file=sys.stderr)
-        print(f"Total errors: {diff.total_errors}", file=sys.stderr)
+        write(new_errors + "\n")
+        write(f"Fixed errors: {diff.num_fixed_errors}\n")
+        write(f"New errors: {diff.num_new_errors}\n")
+        write(f"Total errors: {diff.total_errors}\n")
 
         if diff.num_new_errors or diff.num_fixed_errors:
             return ErrorCodes.ERROR_DIFF

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -264,7 +264,9 @@ class ChangeTracker:
                 line_numbers_by_error[message.message].append(message.line_number)
             messages_by_line_number[message.line_number].append(message.raw)
 
-        old_report_counter: CounterType[str] = Counter(self.old_report.get(filename))
+        old_report_counter: CounterType[str] = Counter(
+            self.old_report.pop(filename, None)
+        )
         new_errors_in_file = error_frequencies - old_report_counter
 
         self.num_new_errors += sum(new_errors_in_file.values())
@@ -278,11 +280,12 @@ class ChangeTracker:
         self.num_fixed_errors += sum(resolved_errors.values())
 
     def diff_report(self) -> DiffReport:
+        unseen_errors = sum(sum(errors.values()) for errors in self.old_report.values())
         return DiffReport(
             error_lines=tuple(self.error_lines),
             total_errors=self.num_errors,
             num_new_errors=self.num_new_errors,
-            num_fixed_errors=self.num_fixed_errors,
+            num_fixed_errors=self.num_fixed_errors + unseen_errors,
         )
 
     def write_report(self) -> Optional[ErrorCodes]:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -101,8 +101,8 @@ ErrorSummary = Dict[str, Dict[str, int]]
 def _load_json_file(filepath: Optional[pathlib.Path]) -> Optional[ErrorSummary]:
     if not filepath:
         return None
-    with filepath.open() as old_report_file:
-        return cast(ErrorSummary, json.load(old_report_file))
+    with filepath.open() as json_file:
+        return cast(ErrorSummary, json.load(json_file))
 
 
 def _parse_command(args: argparse.Namespace) -> None:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -176,14 +176,7 @@ class MypyMessage:
             # Expected to happen on summary lines.
             # We could avoid this by requiring --no-error-summary
             raise ParseError from e
-        elements = location.split(":")
-        num_elements = len(elements)
-        if num_elements == 2:
-            filename, line_number = elements
-        elif num_elements == 3:
-            filename, line_number, _ = elements
-        else:
-            raise ParseError(f"Don't know how to parse: {location}")
+        filename, line_number, *_ = location.split(":")
         return MypyMessage(
             filename=filename,
             line_number=int(line_number),

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -93,8 +93,10 @@ class ParseError(Exception):
 @dataclass(frozen=True)
 class MypyMessage:
     filename: str
+    line_number: int
     message: str
     message_type: str
+    raw: str
 
     @classmethod
     def from_line(cls, line: str) -> "MypyMessage":
@@ -104,10 +106,20 @@ class MypyMessage:
             # Expected to happen on summary lines.
             # We could avoid this by requiring --no-error-summary
             raise ParseError from e
+        elements = location.split(":")
+        num_elements = len(elements)
+        if num_elements == 2:
+            filename, line_number = elements
+        elif num_elements == 3:
+            filename, line_number, _ = elements
+        else:
+            raise ParseError(f"Don't know how to parse: {location}")
         return MypyMessage(
-            filename=location.split(":")[0],
+            filename=filename,
+            line_number=int(line_number),
             message=message,
             message_type=message_type,
+            raw=line,
         )
 
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -97,9 +97,9 @@ def main() -> None:
 ErrorSummary = Dict[str, Dict[str, int]]
 
 
-def _load_json_file(filepath: pathlib.Path) -> Dict[str, Any]:
+def _load_json_file(filepath: pathlib.Path) -> Any:
     with filepath.open() as json_file:
-        return cast(ErrorSummary, json.load(json_file))
+        return json.load(json_file)
 
 
 def _parse_command(args: argparse.Namespace) -> None:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -113,6 +113,8 @@ class ErrorCounter:
         self.grouped_errors: Dict[str, Dict[str, int]] = defaultdict(Counter)
 
     def process_message(self, message: MypyMessage) -> None:
+        if message.message_type != "error":
+            return None
         self.grouped_errors[message.filename][message.message] += 1
 
 
@@ -130,8 +132,6 @@ def extract_message(line: str) -> Optional[MypyMessage]:
     except ValueError:
         # Expected to happen on summary lines.
         # We could avoid this by requiring --no-error-summary
-        return None
-    if message_type != "error":
         return None
     return MypyMessage(
         filename=location.split(":")[0], message=message, message_type=message_type

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -64,7 +64,10 @@ def main() -> None:
 def _parse_command(args: argparse.Namespace) -> None:
     """Handle the `parse` command."""
     error_counter = ErrorCounter()
-    error_counter.parse_errors_report(sys.stdin)
+    messages = _extract_messages(sys.stdin)
+    for message in messages:
+        error_counter.process_message(message)
+
     errors = error_counter.grouped_errors
     error_json = json.dumps(errors, sort_keys=True, indent=args.indentation)
     if args.output_file:
@@ -108,13 +111,6 @@ class ErrorCounter:
 
     def __init__(self) -> None:
         self.grouped_errors: Dict[str, Dict[str, int]] = defaultdict(Counter)
-    def parse_errors_report(self, input_lines: Iterator[str]) -> None:
-        """
-        Given lines from mypy's output, update the summary of error frequencies.
-        """
-        messages = _extract_messages(input_lines)
-        for message in messages:
-            self.process_message(message)
 
     def process_message(self, message: MypyMessage) -> None:
         self.grouped_errors[message.filename][message.message] += 1

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -64,9 +64,11 @@ def main() -> None:
 def _parse_command(args: argparse.Namespace) -> None:
     """Handle the `parse` command."""
     error_counter = ErrorCounter()
+    processors = [error_counter]
     messages = _extract_messages(sys.stdin)
     for message in messages:
-        error_counter.process_message(message)
+        for processor in processors:
+            processor.process_message(message)
 
     errors = error_counter.grouped_errors
     error_json = json.dumps(errors, sort_keys=True, indent=args.indentation)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -102,8 +102,8 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
             ...
         }
     """
-    errors = _extract_messages(input_lines)
-    error_frequencies: CounterType[MypyError] = Counter(errors)
+    messages = _extract_messages(input_lines)
+    error_frequencies: CounterType[MypyError] = Counter(messages)
     grouped_errors: Dict[str, Dict[str, int]] = defaultdict(dict)
     for error, frequency in error_frequencies.items():
         grouped_errors[error.filename][error.message] = frequency

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -102,7 +102,7 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
             ...
         }
     """
-    errors = _extract_errors(input_lines)
+    errors = _extract_messages(input_lines)
     error_frequencies: CounterType[MypyError] = Counter(errors)
     grouped_errors: Dict[str, Dict[str, int]] = defaultdict(dict)
     for error, frequency in error_frequencies.items():
@@ -111,7 +111,7 @@ def parse_errors_report(input_lines: Iterator[str]) -> Dict[str, Dict[str, int]]
     return dict(grouped_errors)
 
 
-def _extract_errors(lines: Iterator[str]) -> Iterator[MypyError]:
+def _extract_messages(lines: Iterator[str]) -> Iterator[MypyError]:
     """Given lines from mypy's output, yield a series of MypyError objects."""
     for line in lines:
         try:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -114,7 +114,10 @@ class ErrorCounter:
         """
         messages = _extract_messages(input_lines)
         for message in messages:
-            self.grouped_errors[message.filename][message.message] += 1
+            self.process_message(message)
+
+    def process_message(self, message: MypyMessage) -> None:
+        self.grouped_errors[message.filename][message.message] += 1
 
 
 def _extract_messages(lines: Iterator[str]) -> Iterator[MypyMessage]:

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -81,7 +81,7 @@ def main() -> None:
             f"""\
             An old report to compare against. We will compare the errors in there to the new report.
             Fail with return code {ErrorCodes.ERROR_DIFF} if we discover any new errors.
-            New errors will be printed to strerr.
+            New errors will be printed to stderr.
             Similar errors from the same file will also be printed
             (because we don't know which error is the new one).
             For completeness other hints and errors on the same lines are also printed.

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -31,7 +31,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Tuple,
     Union,
     cast,
 )
@@ -221,7 +220,7 @@ class ErrorCounter:
 
 @dataclass(frozen=True)
 class DiffReport:
-    error_lines: Tuple[str, ...]
+    error_lines: List[str]
     total_errors: int
     num_new_errors: int
     num_fixed_errors: int
@@ -273,7 +272,7 @@ class ChangeTracker:
     def diff_report(self) -> DiffReport:
         unseen_errors = sum(sum(errors.values()) for errors in self.old_report.values())
         return DiffReport(
-            error_lines=tuple(self.error_lines),
+            error_lines=self.error_lines,
             total_errors=self.num_errors,
             num_new_errors=self.num_new_errors,
             num_fixed_errors=self.num_fixed_errors + unseen_errors,

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,4 +1,6 @@
-from mypy_json_report import ErrorCounter, MypyMessage, extract_message
+import pytest
+
+from mypy_json_report import ErrorCounter, MypyMessage, ParseError, extract_message
 
 
 EXAMPLE_MYPY_STDOUT = """\
@@ -34,9 +36,8 @@ class TestExtractMessage:
     def test_summary_line(self) -> None:
         line = "Found 2 errors in 1 file (checked 3 source files)"
 
-        message = extract_message(line)
-
-        assert message is None
+        with pytest.raises(ParseError):
+            extract_message(line)
 
 
 class TestErrorCounter:

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -25,7 +25,11 @@ class TestExtractMessage:
 
         message = extract_message(line)
 
-        assert message is None
+        assert message == MypyMessage(
+            filename="test.py",
+            message='Use "-> None" if function does not return a value',
+            message_type="note",
+        )
 
     def test_summary_line(self) -> None:
         line = "Found 2 errors in 1 file (checked 3 source files)"
@@ -64,3 +68,16 @@ class TestErrorCounter:
         assert error_counter.grouped_errors == {
             "file.py": {"An example type error": 2},
         }
+
+    def test_notes_uncounted(self) -> None:
+        error_counter = ErrorCounter()
+        message = MypyMessage(
+            filename="file.py",
+            message="An example note",
+            message_type="note",
+        )
+
+        error_counter.process_message(message)
+
+        # The note was not added to the grouped_errors.
+        assert error_counter.grouped_errors == {}

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -12,7 +12,8 @@ Found 2 errors in 1 file (checked 3 source files)"""
 
 def test_parse_errors_report() -> None:
     error_counter = ErrorCounter()
-    report = error_counter.parse_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
+    error_counter.parse_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
+    report = error_counter.grouped_errors
 
     assert report == {
         "mypy_json_report.py": {

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -48,3 +48,34 @@ def test_parse_errors_report() -> None:
             "Function is missing a return type annotation": 1,
         }
     }
+
+
+class TestErrorCounter:
+    def test_new_unseen_error(self) -> None:
+        error_counter = ErrorCounter()
+        message = MypyMessage(
+            filename="file.py",
+            message="An example type error",
+            message_type="error",
+        )
+
+        error_counter.process_message(message)
+
+        assert error_counter.grouped_errors == {
+            "file.py": {"An example type error": 1},
+        }
+
+    def test_errors_counted(self) -> None:
+        error_counter = ErrorCounter()
+        message = MypyMessage(
+            filename="file.py",
+            message="An example type error",
+            message_type="error",
+        )
+
+        error_counter.process_message(message)
+        error_counter.process_message(message)
+
+        assert error_counter.grouped_errors == {
+            "file.py": {"An example type error": 2},
+        }

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from mypy_json_report import parse_errors_report
+from mypy_json_report import ErrorCounter
 
 
 EXAMPLE_MYPY_STDOUT = """\
@@ -11,7 +11,8 @@ Found 2 errors in 1 file (checked 3 source files)"""
 
 
 def test_parse_errors_report() -> None:
-    report = parse_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
+    error_counter = ErrorCounter()
+    report = error_counter.parse_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
 
     assert report == {
         "mypy_json_report.py": {

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -68,7 +68,7 @@ class TestErrorCounter:
         error_counter = ErrorCounter()
         message = MypyMessage.from_line("file.py:8: error: An example type error")
 
-        error_counter.process_message(message)
+        error_counter.process_messages("file.py", [message])
 
         assert error_counter.grouped_errors == {
             "file.py": {"An example type error": 1},
@@ -78,8 +78,7 @@ class TestErrorCounter:
         error_counter = ErrorCounter()
         message = MypyMessage.from_line("file.py:8: error: An example type error")
 
-        error_counter.process_message(message)
-        error_counter.process_message(message)
+        error_counter.process_messages("file.py", [message, message])
 
         assert error_counter.grouped_errors == {
             "file.py": {"An example type error": 2},
@@ -89,7 +88,7 @@ class TestErrorCounter:
         error_counter = ErrorCounter()
         message = MypyMessage.from_line("file.py:8: note: An example note")
 
-        error_counter.process_message(message)
+        error_counter.process_messages("file.py", [message])
 
         # The note was not added to the grouped_errors.
         assert error_counter.grouped_errors == {}
@@ -107,8 +106,9 @@ class TestChangeTracker:
 
     def test_new_error(self) -> None:
         tracker = ChangeTracker(summary={})
-        tracker.process_message(
-            MypyMessage.from_line("file.py:8: error: An example type error")
+        tracker.process_messages(
+            "file.py",
+            [MypyMessage.from_line("file.py:8: error: An example type error")],
         )
 
         report = tracker.diff_report()
@@ -122,8 +122,9 @@ class TestChangeTracker:
 
     def test_known_error(self) -> None:
         tracker = ChangeTracker(summary={"file.py": {"An example type error": 1}})
-        tracker.process_message(
-            MypyMessage.from_line("file.py:8: error: An example type error")
+        tracker.process_messages(
+            "file.py",
+            [MypyMessage.from_line("file.py:8: error: An example type error")],
         )
 
         report = tracker.diff_report()
@@ -134,8 +135,9 @@ class TestChangeTracker:
 
     def test_fixed_error(self) -> None:
         tracker = ChangeTracker(summary={"file.py": {"An example type error": 2}})
-        tracker.process_message(
-            MypyMessage.from_line("file.py:8: error: An example type error")
+        tracker.process_messages(
+            "file.py",
+            [MypyMessage.from_line("file.py:8: error: An example type error")],
         )
 
         report = tracker.diff_report()
@@ -149,14 +151,13 @@ class TestChangeTracker:
 
     def test_more_errors_of_same_type(self) -> None:
         tracker = ChangeTracker(summary={"file.py": {"An example type error": 1}})
-        tracker.process_message(
-            MypyMessage.from_line("file.py:1: error: An example type error")
-        )
-        tracker.process_message(
-            MypyMessage.from_line("file.py:2: error: An example type error")
-        )
-        tracker.process_message(
-            MypyMessage.from_line("file.py:3: error: An example type error")
+        tracker.process_messages(
+            "file.py",
+            [
+                MypyMessage.from_line("file.py:1: error: An example type error"),
+                MypyMessage.from_line("file.py:2: error: An example type error"),
+                MypyMessage.from_line("file.py:3: error: An example type error"),
+            ],
         )
 
         report = tracker.diff_report()
@@ -174,11 +175,12 @@ class TestChangeTracker:
 
     def test_note_on_same_line(self) -> None:
         tracker = ChangeTracker(summary={})
-        tracker.process_message(
-            MypyMessage.from_line("file.py:1: error: An example type error")
-        )
-        tracker.process_message(
-            MypyMessage.from_line("file.py:1: note: An example note")
+        tracker.process_messages(
+            "file.py",
+            [
+                MypyMessage.from_line("file.py:1: error: An example type error"),
+                MypyMessage.from_line("file.py:1: note: An example note"),
+            ],
         )
 
         report = tracker.diff_report()
@@ -195,11 +197,13 @@ class TestChangeTracker:
 
     def test_error_in_new_file(self) -> None:
         tracker = ChangeTracker(summary={"file.py": {"An example type error": 1}})
-        tracker.process_message(
-            MypyMessage.from_line("file.py:1: error: An example type error")
+        tracker.process_messages(
+            "file.py",
+            [MypyMessage.from_line("file.py:1: error: An example type error")],
         )
-        tracker.process_message(
-            MypyMessage.from_line("other.py:1: error: An example type error")
+        tracker.process_messages(
+            "other.py",
+            [MypyMessage.from_line("other.py:1: error: An example type error")],
         )
 
         report = tracker.diff_report()

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from mypy_json_report import ErrorCounter
+from mypy_json_report import ErrorCounter, MypyMessage, extract_message
 
 
 EXAMPLE_MYPY_STDOUT = """\
@@ -8,6 +8,31 @@ mypy_json_report.py:8: error: Function is missing a return type annotation
 mypy_json_report.py:8: note: Use "-> None" if function does not return a value
 mypy_json_report.py:68: error: Call to untyped function "main" in typed context
 Found 2 errors in 1 file (checked 3 source files)"""
+
+
+class TestExtractMessage:
+    def test_error(self) -> None:
+        line = "test.py:8: error: Function is missing a return type annotation"
+
+        message = extract_message(line)
+
+        assert message == MypyMessage(
+            filename="test.py", message="Function is missing a return type annotation"
+        )
+
+    def test_note(self) -> None:
+        line = 'test.py:8: note: Use "-> None" if function does not return a value'
+
+        message = extract_message(line)
+
+        assert message is None
+
+    def test_summary_line(self) -> None:
+        line = "Found 2 errors in 1 file (checked 3 source files)"
+
+        message = extract_message(line)
+
+        assert message is None
 
 
 def test_parse_errors_report() -> None:

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -17,7 +17,9 @@ class TestExtractMessage:
         message = extract_message(line)
 
         assert message == MypyMessage(
-            filename="test.py", message="Function is missing a return type annotation"
+            filename="test.py",
+            message="Function is missing a return type annotation",
+            message_type="error",
         )
 
     def test_note(self) -> None:

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mypy_json_report import ErrorCounter, MypyMessage, ParseError, extract_message
+from mypy_json_report import ErrorCounter, MypyMessage, ParseError
 
 
 EXAMPLE_MYPY_STDOUT = """\
@@ -10,11 +10,11 @@ mypy_json_report.py:68: error: Call to untyped function "main" in typed context
 Found 2 errors in 1 file (checked 3 source files)"""
 
 
-class TestExtractMessage:
+class TestMypyMessageFromLine:
     def test_error(self) -> None:
         line = "test.py:8: error: Function is missing a return type annotation"
 
-        message = extract_message(line)
+        message = MypyMessage.from_line(line)
 
         assert message == MypyMessage(
             filename="test.py",
@@ -25,7 +25,7 @@ class TestExtractMessage:
     def test_note(self) -> None:
         line = 'test.py:8: note: Use "-> None" if function does not return a value'
 
-        message = extract_message(line)
+        message = MypyMessage.from_line(line)
 
         assert message == MypyMessage(
             filename="test.py",
@@ -37,7 +37,7 @@ class TestExtractMessage:
         line = "Found 2 errors in 1 file (checked 3 source files)"
 
         with pytest.raises(ParseError):
-            extract_message(line)
+            MypyMessage.from_line(line)
 
 
 class TestErrorCounter:

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -182,7 +182,16 @@ class TestChangeTracker:
             error_lines=(), total_errors=1, num_new_errors=0, num_fixed_errors=0
         )
 
-    def test_fixed_error(self) -> None:
+    def test_error_completely_fixed(self) -> None:
+        tracker = ChangeTracker(summary={"file.py": {"An example type error": 2}})
+
+        report = tracker.diff_report()
+
+        assert report == DiffReport(
+            error_lines=(), total_errors=0, num_new_errors=0, num_fixed_errors=2
+        )
+
+    def test_error_partially_fixed(self) -> None:
         tracker = ChangeTracker(summary={"file.py": {"An example type error": 2}})
         tracker.process_messages(
             "file.py",

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -1,5 +1,3 @@
-from io import StringIO
-
 from mypy_json_report import ErrorCounter, MypyMessage, extract_message
 
 
@@ -35,19 +33,6 @@ class TestExtractMessage:
         message = extract_message(line)
 
         assert message is None
-
-
-def test_parse_errors_report() -> None:
-    error_counter = ErrorCounter()
-    error_counter.parse_errors_report(StringIO(EXAMPLE_MYPY_STDOUT))
-    report = error_counter.grouped_errors
-
-    assert report == {
-        "mypy_json_report.py": {
-            'Call to untyped function "main" in typed context': 1,
-            "Function is missing a return type annotation": 1,
-        }
-    }
 
 
 class TestErrorCounter:

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -150,7 +150,7 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=(), total_errors=0, num_new_errors=0, num_fixed_errors=0
+            error_lines=[], total_errors=0, num_new_errors=0, num_fixed_errors=0
         )
 
     def test_new_error(self) -> None:
@@ -163,7 +163,7 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=("file.py:8: error: An example type error",),
+            error_lines=["file.py:8: error: An example type error"],
             total_errors=1,
             num_new_errors=1,
             num_fixed_errors=0,
@@ -179,7 +179,7 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=(), total_errors=1, num_new_errors=0, num_fixed_errors=0
+            error_lines=[], total_errors=1, num_new_errors=0, num_fixed_errors=0
         )
 
     def test_error_completely_fixed(self) -> None:
@@ -188,7 +188,7 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=(), total_errors=0, num_new_errors=0, num_fixed_errors=2
+            error_lines=[], total_errors=0, num_new_errors=0, num_fixed_errors=2
         )
 
     def test_error_partially_fixed(self) -> None:
@@ -201,7 +201,7 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=(),
+            error_lines=[],
             total_errors=1,
             num_new_errors=0,
             num_fixed_errors=1,
@@ -221,11 +221,11 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=(
+            error_lines=[
                 "file.py:1: error: An example type error",
                 "file.py:2: error: An example type error",
                 "file.py:3: error: An example type error",
-            ),
+            ],
             total_errors=3,
             num_new_errors=2,
             num_fixed_errors=0,
@@ -244,10 +244,10 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=(
+            error_lines=[
                 "file.py:1: error: An example type error",
                 "file.py:1: note: An example note",
-            ),
+            ],
             total_errors=1,
             num_new_errors=1,
             num_fixed_errors=0,
@@ -267,7 +267,7 @@ class TestChangeTracker:
         report = tracker.diff_report()
 
         assert report == DiffReport(
-            error_lines=("other.py:1: error: An example type error",),
+            error_lines=["other.py:1: error: An example type error"],
             total_errors=2,
             num_new_errors=1,
             num_fixed_errors=0,

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -18,7 +18,7 @@ Found 2 errors in 1 file (checked 3 source files)"""
 
 class TestMypyMessageFromLine:
     def test_error(self) -> None:
-        line = "test.py:8: error: Function is missing a return type annotation"
+        line = "test.py:8: error: Function is missing a return type annotation\n"
 
         message = MypyMessage.from_line(line)
 
@@ -27,11 +27,11 @@ class TestMypyMessageFromLine:
             line_number=8,
             message="Function is missing a return type annotation",
             message_type="error",
-            raw=line,
+            raw="test.py:8: error: Function is missing a return type annotation",
         )
 
     def test_note(self) -> None:
-        line = 'test.py:8: note: Use "-> None" if function does not return a value'
+        line = 'test.py:8: note: Use "-> None" if function does not return a value\n'
 
         message = MypyMessage.from_line(line)
 
@@ -40,7 +40,7 @@ class TestMypyMessageFromLine:
             line_number=8,
             message='Use "-> None" if function does not return a value',
             message_type="note",
-            raw=line,
+            raw='test.py:8: note: Use "-> None" if function does not return a value',
         )
 
     def test_line_with_column(self) -> None:
@@ -57,7 +57,7 @@ class TestMypyMessageFromLine:
         )
 
     def test_summary_line(self) -> None:
-        line = "Found 2 errors in 1 file (checked 3 source files)"
+        line = "Found 2 errors in 1 file (checked 3 source files)\n"
 
         with pytest.raises(ParseError):
             MypyMessage.from_line(line)

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -62,6 +62,32 @@ class TestMypyMessageFromLine:
         with pytest.raises(ParseError):
             MypyMessage.from_line(line)
 
+    def test_multiple_lines(self) -> None:
+        lines = [
+            "test.py:8: error: Function is missing a return type annotation\n",
+            'test.py:8: note: Use "-> None" if function does not return a value\n',
+            "Found 1 error in 1 file (checked 3 source files)\n",
+        ]
+
+        messages = list(MypyMessage.from_lines(lines))
+
+        assert messages == [
+            MypyMessage(
+                filename="test.py",
+                line_number=8,
+                message="Function is missing a return type annotation",
+                message_type="error",
+                raw="test.py:8: error: Function is missing a return type annotation",
+            ),
+            MypyMessage(
+                filename="test.py",
+                line_number=8,
+                message='Use "-> None" if function does not return a value',
+                message_type="note",
+                raw='test.py:8: note: Use "-> None" if function does not return a value',
+            ),
+        ]
+
 
 class TestErrorCounter:
     def test_new_unseen_error(self) -> None:

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -18,8 +18,10 @@ class TestMypyMessageFromLine:
 
         assert message == MypyMessage(
             filename="test.py",
+            line_number=8,
             message="Function is missing a return type annotation",
             message_type="error",
+            raw=line,
         )
 
     def test_note(self) -> None:
@@ -29,8 +31,23 @@ class TestMypyMessageFromLine:
 
         assert message == MypyMessage(
             filename="test.py",
+            line_number=8,
             message='Use "-> None" if function does not return a value',
             message_type="note",
+            raw=line,
+        )
+
+    def test_line_with_column(self) -> None:
+        line = 'test.py:88:16: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "get"  [union-attr]\n'
+
+        message = MypyMessage.from_line(line)
+
+        assert message == MypyMessage(
+            filename="test.py",
+            line_number=88,
+            message='Item "None" of "Optional[Dict[str, Any]]" has no attribute "get"  [union-attr]',
+            message_type="error",
+            raw='test.py:88:16: error: Item "None" of "Optional[Dict[str, Any]]" has no attribute "get"  [union-attr]',
         )
 
     def test_summary_line(self) -> None:

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -43,11 +43,7 @@ class TestMypyMessageFromLine:
 class TestErrorCounter:
     def test_new_unseen_error(self) -> None:
         error_counter = ErrorCounter()
-        message = MypyMessage(
-            filename="file.py",
-            message="An example type error",
-            message_type="error",
-        )
+        message = MypyMessage.from_line("file.py:8: error: An example type error")
 
         error_counter.process_message(message)
 
@@ -57,11 +53,7 @@ class TestErrorCounter:
 
     def test_errors_counted(self) -> None:
         error_counter = ErrorCounter()
-        message = MypyMessage(
-            filename="file.py",
-            message="An example type error",
-            message_type="error",
-        )
+        message = MypyMessage.from_line("file.py:8: error: An example type error")
 
         error_counter.process_message(message)
         error_counter.process_message(message)
@@ -72,11 +64,7 @@ class TestErrorCounter:
 
     def test_notes_uncounted(self) -> None:
         error_counter = ErrorCounter()
-        message = MypyMessage(
-            filename="file.py",
-            message="An example note",
-            message_type="note",
-        )
+        message = MypyMessage.from_line("file.py:8: note: An example note")
 
         error_counter.process_message(message)
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,4 @@ allowlist_externals =
 commands_pre =
     poetry install
 commands =
-    poetry run bash -c "mypy . --strict | mypy-json-report parse > known-mypy-errors.json"
-    git diff --exit-code known-mypy-errors.json
+    poetry run bash -c "mypy . --strict | mypy-json-report parse --output-file known-mypy-errors.json --diff-old-report known-mypy-errors.json"


### PR DESCRIPTION
This PR introduces the `--diff-old-report` flag. By printing (to STDERR) the new errors that have appeared since the last JSON report, this saves users from having to re-run Mypy to find hints and line numbers related to new type errors. When new or newly-fixed errors are detected, we fail with an exit code of 4. This makes the script more suitable for use in pre-commit (integration with which is out of scope of this PR).

As an example, if I remove `-> None` from the definition of `main()`. We see two new errors, and  the STDERR output looks like this:

```shell
$ mypy . --strict | mypy-json-report parse -d known-mypy-errors.json -o known-mypy-errors.json
mypy_json_report.py:31: error: Function is missing a return type annotation  [no-untyped-def]
mypy_json_report.py:31: note: Use "-> None" if function does not return a value
mypy_json_report.py:278: error: Call to untyped function "main" in typed context  [no-untyped-call]
Fixed errors: 0
New errors: 2
Total errors: 2
```

Significant refactoring was done so that handling lines of the Mypy report was separated from parsing, and to keep this new logic isolated from the existing logic that merely counts errors. Please let me know if you would prefer me to separate that refactor into a separate PR before this functionality is merged.

Builds upon #29, which adds the `-o` flag. This is required because we can't read from a file that we're piping STDOUT to. By the time we come to read the file, it's already been overwritten.
