### PR TITLE
Handle lines from mypy being out of order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Handle mypy emitting output for files out of order.
+
 ## v1.0.0 [2022-09-07]
 
 - *Action required:* Move existing behaviour under "parse" subcommand.

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -120,8 +120,13 @@ def _parse_command(args: argparse.Namespace) -> None:
         processors.append(tracker)
 
     messages = MypyMessage.from_lines(sys.stdin)
+
+    # Sort the lines by the filename otherwise itertools.groupby() will make
+    # multiple groups for the same file name if the lines are out of order.
+    messages_sorted = sorted(list(messages), key=operator.attrgetter("filename"))
+
     for filename, messages in itertools.groupby(
-        messages, key=operator.attrgetter("filename")
+        messages_sorted, key=operator.attrgetter("filename")
     ):
         # Send each line of the Mypy report to each processor.
         message_group = list(messages)

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -123,7 +123,7 @@ def _parse_command(args: argparse.Namespace) -> None:
 
     # Sort the lines by the filename otherwise itertools.groupby() will make
     # multiple groups for the same file name if the lines are out of order.
-    messages_sorted = sorted(list(messages), key=operator.attrgetter("filename"))
+    messages_sorted = sorted(messages, key=operator.attrgetter("filename"))
 
     for filename, messages in itertools.groupby(
         messages_sorted, key=operator.attrgetter("filename")


### PR DESCRIPTION
Out of order meaning we do not get all lines for a given file consecutively.

We have to sort the input lines for `itertools.groupby()` to be able to group all the lines together related to a single filename, otherwise `ErrorCounter` will not count the errors up correctly.

When upgrading a code base using mypy-json-report to version 1.0.0, I noticed I sometimes got a diff in the counted errors, and worked out the errors were underreported for one specific Python file, but only if mypy was run with a clean cache. If the cache was populated the error count was consistent with mypy-json-report 0.1.3 numbers.

When mypy was running with a populated cache, the output related to the file in question was:

```
tests/log_events/test_events.py:306: error: Unexpected keyword argument "payment_method" for "AbstractLogEvent"  [call-arg]
tests/log_events/test_events.py:306: error: "AbstractLogEvent" has no attribute "payment_method"  [attr-defined]
tests/log_events/test_events.py:316: error: Unexpected keyword argument "payment_method" for "AbstractLogEvent"  [call-arg]
tests/log_events/test_events.py:316: error: "AbstractLogEvent" has no attribute "payment_method"  [attr-defined]
tests/log_events/test_events.py:327: error: Unexpected keyword argument "payment_method" for "AbstractLogEvent"  [call-arg]
tests/log_events/test_events.py:348: error: Argument 1 to "len" has incompatible type "Iterable[LogEventLookup]"; expected "Sized"  [arg-type]
```

but if the cache is cleared the output is instead:

```
tests/log_events/test_events.py:306: error: Unexpected keyword argument "payment_method" for "AbstractLogEvent"  [call-arg]
/Users/jeppe/.pyenv/versions/3.11.1/envs/venv/lib/python3.11/site-packages/mypy/typeshed/stdlib/builtins.pyi:89: note: "AbstractLogEvent" defined here
tests/log_events/test_events.py:306: error: "AbstractLogEvent" has no attribute "payment_method"  [attr-defined]
tests/log_events/test_events.py:316: error: Unexpected keyword argument "payment_method" for "AbstractLogEvent"  [call-arg]
/Users/jeppe/.pyenv/versions/3.11.1/envs/venv/lib/python3.11/site-packages/mypy/typeshed/stdlib/builtins.pyi:89: note: "AbstractLogEvent" defined here
tests/log_events/test_events.py:316: error: "AbstractLogEvent" has no attribute "payment_method"  [attr-defined]
tests/log_events/test_events.py:327: error: Unexpected keyword argument "payment_method" for "AbstractLogEvent"  [call-arg]
/Users/jeppe/.pyenv/versions/3.11.1/envs/venv/lib/python3.11/site-packages/mypy/typeshed/stdlib/builtins.pyi:89: note: "AbstractLogEvent" defined here
tests/log_events/test_events.py:348: error: Argument 1 to "len" has incompatible type "Iterable[LogEventLookup]"; expected "Sized"  [arg-type]
```

This causes a problem for mypy-json-report because `ErrorCounter` expects to only ever see one call to `process_messages` per filename, otherwise, it overwrites the previous error count.

---

I could also have fixed this by making `ErrorCounter` add the errors found up into the existing errors for the filename in question, but I thought it probably was nicer to make sure our assumption of one call to `process_messages` per filename holds up, rather than making sure each processor can handle multiple calls of `process_messages` per filename. This does however come at the cost of a higher memory usage since the entire mypy output has to be kept in memory for it to be sorted. Considering the tool usually have a runtime measured in seconds I thought this probably was okay.