### PR TITLE
Only report the messages on each line once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix duplicated reporting of new errors when multiple errors occurred on the same line.
+
 ## v1.0.1 [2023-02-28]
 
 - Handle mypy emitting output for files out of order.

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -266,7 +266,7 @@ class ChangeTracker:
         self.num_new_errors += sum(new_errors_in_file.values())
         for new_error in new_errors_in_file:
             for line_number in line_numbers_by_error[new_error]:
-                self.error_lines.extend(messages_by_line_number[line_number])
+                self.error_lines.extend(messages_by_line_number.pop(line_number, []))
 
         # Find counts for errors resolved.
         resolved_errors = old_report_counter - error_frequencies

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -272,3 +272,25 @@ class TestChangeTracker:
             num_new_errors=1,
             num_fixed_errors=0,
         )
+
+    def test_multiple_errors_on_same_line(self) -> None:
+        tracker = ChangeTracker(summary={})
+        tracker.process_messages(
+            "file.py",
+            [
+                MypyMessage.from_line("file.py:1: error: An example type error"),
+                MypyMessage.from_line("file.py:1: error: Another example type error"),
+            ],
+        )
+
+        report = tracker.diff_report()
+
+        assert report == DiffReport(
+            error_lines=[
+                "file.py:1: error: An example type error",
+                "file.py:1: error: Another example type error",
+            ],
+            total_errors=2,
+            num_new_errors=2,
+            num_fixed_errors=0,
+        )


### PR DESCRIPTION
Before this change, when multiple errors occurred on the same line, we would report them multiple times.

This change ensures that new errors are only reported once by removing them from the store of messages the first time we report them.

The included test was failing with this error before the fix:
```
E             [
E              'file.py:1: error: An example type error',
E              'file.py:1: error: Another example type error',
E           +  'file.py:1: error: An example type error',
E           +  'file.py:1: error: Another example type error',
E             ]
```