### PR TITLE
Switch to use Trusted Publishing when releasing new versions to PyPI

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -7,7 +7,7 @@ on:
       - v*
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
@@ -29,8 +29,25 @@ jobs:
       - name: Build package
         run: poetry build
 
-      - name: Upload to PyPI
-        env:
-          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: poetry publish
+      - name: Store release files
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: dist/
+
+  upload:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Fetch release files
+        uses: actions/download-artifact@v3
+        with:
+          name: release
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make use of [Trusted Publishing](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) when releasing new versions to PyPI.
 
 ## v1.0.2 [2023-04-10]
 


### PR DESCRIPTION
It is explained in the blog post announcing the functionality at https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/.

It means we no longer need to have secrets configured for the repository used for publishing to PyPI. OpenID Connect is instead used to produce a short-lived token which can be used instead.