### PR TITLE
Replace isort and pyupgrade with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,10 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.265
     hooks:
-      - id: isort
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
-    hooks:
-      - id: pyupgrade
+      - id: ruff
         args:
-          - --py37-plus
+          - --fix
+          - --exit-non-zero-on-fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Make use of [Trusted Publishing](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) when releasing new versions to PyPI.
+- Replace isort and pyupgrade with ruff for code linting.
 
 ## v1.0.2 [2023-04-10]
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -136,7 +136,7 @@ def _parse_command(args: argparse.Namespace) -> None:
     for processor in processors:
         error_code = processor.write_report()
         if error_code is not None:
-            exit(error_code)
+            sys.exit(error_code)
 
 
 def _no_command(args: argparse.Namespace) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,19 @@ mypy-json-report = "mypy_json_report:main"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.isort]
-combine_as_imports = true
-known_first_party = ["mypy_json_report"]
-lines_after_imports = 2
-profile = "black"
+[tool.ruff]
+target-version = "py37"
+select = [
+    "E",  # pycodestyle
+    "F",  # Pyflakes
+    "I",  # isort
+    "PL",  # Pylint
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # Line too long
+]
+
+[tool.ruff.isort]
+combine-as-imports = true
+lines-after-imports = 2


### PR DESCRIPTION
It's much faster and includes lots of linter checks as well.

There was one violation found which has been fixed, and the remaining pre-commit hooks have also been upgraded.