### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -38,6 +38,8 @@ jobs:
   upload:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    needs:
+      - build
 
     permissions:
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix release workflow by declaring missing dependency.
+
 ## v1.0.3 [2023-05-09]
 
 - Make use of [Trusted Publishing](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) when releasing new versions to PyPI.


### PR DESCRIPTION
It actually didn't break when I tried to release version 1.0.3, but that was pure luck because the `pypa/gh-action-pypi-publish` GitHub Action took a while to get set up, so it didn't end up trying to fetch the release files before they had been uploaded.

Specifying the dependency however makes sure we won't have a problem with this going forward.