### PR TITLE
Add flag for printing reports in colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Drop support for Python 3.7
+- Add `parse --color` flag for printing out change reports in color. (Aliases `-c`, `--colour`.)
 
 ## v1.0.4 [2023-05-09]
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -255,7 +255,8 @@ class DefaultChangeReportWriter:
 
     def write_report(self, diff: DiffReport) -> None:
         new_errors = "\n".join(diff.error_lines)
-        self.write(new_errors + "\n")
+        if new_errors:
+            self.write(new_errors + "\n\n")
         self.write(f"Fixed errors: {diff.num_fixed_errors}\n")
         self.write(f"New errors: {diff.num_new_errors}\n")
         self.write(f"Total errors: {diff.total_errors}\n")
@@ -283,7 +284,8 @@ class ColorChangeReportWriter:
 
     def write_report(self, diff: DiffReport) -> None:
         new_errors = "\n".join([self._format_line(line) for line in diff.error_lines])
-        self.write(new_errors + "\n")
+        if new_errors:
+            self.write(new_errors + "\n\n")
 
         fixed_color = self._BOLD_YELLOW if diff.num_fixed_errors else self._GREEN
         error_color = self._BOLD_RED if diff.num_new_errors else self._GREEN

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -248,6 +248,81 @@ class DefaultChangeReportWriter:
         self.write(f"Total errors: {diff.total_errors}\n")
 
 
+class ColorChangeReportWriter:
+    """
+    Writes an error summary in color.
+
+    Inspired by the FancyFormatter in mypy.util.
+
+    Ref: https://github.com/python/mypy/blob/f9e8e0bda5cfbb54d6a8f9e482aa25da28a1a635/mypy/util.py#L761
+    """
+
+    _RESET = "\033[0m"
+    _BOLD = "\033[1m"
+    _BOLD_RED = "\033[31;1m"
+    _BOLD_YELLOW = "\033[33;1m"
+    _GREEN = "\033[32m"
+    _YELLOW = "\033[33m"
+    _BLUE = "\033[34m"
+
+    def __init__(self, _write: Callable[[str], Any] = sys.stdout.write) -> None:
+        self.write = _write
+
+    def write_report(self, diff: DiffReport) -> None:
+        new_errors = "\n".join([self._format_line(line) for line in diff.error_lines])
+        self.write(new_errors + "\n")
+
+        fixed_color = self._BOLD_YELLOW if diff.num_fixed_errors else self._GREEN
+        error_color = self._BOLD_RED if diff.num_new_errors else self._GREEN
+
+        self.write(self._style(fixed_color, f"Fixed errors: {diff.num_fixed_errors}\n"))
+        self.write(self._style(error_color, f"New errors: {diff.num_new_errors}\n"))
+        self.write(self._style(self._BOLD, f"Total errors: {diff.total_errors}\n"))
+
+    def _style(self, style: str, message: str) -> str:
+        return f"{style}{message}{self._RESET}"
+
+    def _highlight_quotes(self, msg: str) -> str:
+        if msg.count('"') % 2:
+            return msg
+        parts = msg.split('"')
+        out = ""
+        for i, part in enumerate(parts):
+            if i % 2 == 0:
+                out += part
+            else:
+                out += self._style(self._BOLD, f'"{part}"')
+        return out
+
+    def _format_line(self, line: str) -> str:
+        if ": error: " in line:
+            # Separate the location from the message.
+            location, _, message = line.partition(" error: ")
+
+            # Extract the error code from the end of the message if it's there.
+            if message.endswith("]") and "  [" in message:
+                error_msg, _, code = message.rpartition("  [")
+                code = self._style(self._YELLOW, f"  [{code}")
+            else:
+                error_msg = message
+                code = ""
+
+            return (
+                location
+                + self._style(self._BOLD_RED, " error: ")
+                + self._highlight_quotes(error_msg)
+                + code
+            )
+        if ": note: " in line:
+            location, _, message = line.partition(" note: ")
+            return (
+                location
+                + self._style(self._BLUE, " note: ")
+                + self._highlight_quotes(message)
+            )
+        return line
+
+
 class ChangeTracker:
     """
     Compares the current Mypy report against a previous summary.

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -88,6 +88,13 @@ def main() -> None:
             """
         ),
     )
+    parse_parser.add_argument(
+        "-c",
+        "--color",
+        "--colour",
+        action="store_true",
+        help="Whether to colorize the diff-report output. Defaults to False.",
+    )
 
     parse_parser.set_defaults(func=_parse_command)
 
@@ -117,7 +124,11 @@ def _parse_command(args: argparse.Namespace) -> None:
     tracker = None
     if args.diff_old_report is not None:
         old_report = cast(ErrorSummary, _load_json_file(args.diff_old_report))
-        change_report_writer = DefaultChangeReportWriter()
+        change_report_writer: _ChangeReportWriter
+        if args.color:
+            change_report_writer = ColorChangeReportWriter()
+        else:
+            change_report_writer = DefaultChangeReportWriter()
         tracker = ChangeTracker(old_report, report_writer=change_report_writer)
         processors.append(tracker)
 

--- a/mypy_json_report.py
+++ b/mypy_json_report.py
@@ -248,6 +248,8 @@ class _ChangeReportWriter(Protocol):
 
 
 class DefaultChangeReportWriter:
+    """Writes an error summary without color."""
+
     def __init__(self, _write: Callable[[str], Any] = sys.stdout.write) -> None:
         self.write = _write
 

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -12,13 +12,6 @@ from mypy_json_report import (
 )
 
 
-EXAMPLE_MYPY_STDOUT = """\
-mypy_json_report.py:8: error: Function is missing a return type annotation
-mypy_json_report.py:8: note: Use "-> None" if function does not return a value
-mypy_json_report.py:68: error: Call to untyped function "main" in typed context
-Found 2 errors in 1 file (checked 3 source files)"""
-
-
 class TestMypyMessageFromLine:
     def test_error(self) -> None:
         line = "test.py:8: error: Function is missing a return type annotation\n"

--- a/tests/test_mypy_json_report.py
+++ b/tests/test_mypy_json_report.py
@@ -332,12 +332,7 @@ class TestDefaultChangeReportWriter:
             )
         )
 
-        assert messages == [
-            "\n",
-            "Fixed errors: 0\n",
-            "New errors: 0\n",
-            "Total errors: 0\n",
-        ]
+        assert messages == ["Fixed errors: 0\n", "New errors: 0\n", "Total errors: 0\n"]
 
     def test_with_errors(self) -> None:
         messages: List[str] = []
@@ -353,7 +348,7 @@ class TestDefaultChangeReportWriter:
         )
 
         assert messages == [
-            "file.py:8: error: An example type error\n",
+            "file.py:8: error: An example type error\n\n",
             "Fixed errors: 0\n",
             "New errors: 1\n",
             "Total errors: 2\n",
@@ -372,7 +367,6 @@ class TestColorChangeReportWriter:
         )
 
         assert messages == [
-            "\n",
             "\x1b[32mFixed errors: 0\n\x1b[0m",
             "\x1b[32mNew errors: 0\n\x1b[0m",
             "\x1b[1mTotal errors: 0\n\x1b[0m",
@@ -392,7 +386,7 @@ class TestColorChangeReportWriter:
         )
 
         assert messages == [
-            "file.py:8:\x1b[31;1m error: \x1b[0mAn example type error\n",
+            "file.py:8:\x1b[31;1m error: \x1b[0mAn example type error\n\n",
             "\x1b[33;1mFixed errors: 1\n\x1b[0m",
             "\x1b[31;1mNew errors: 1\n\x1b[0m",
             "\x1b[1mTotal errors: 2\n\x1b[0m",
@@ -414,7 +408,7 @@ class TestColorChangeReportWriter:
         )
 
         assert messages == [
-            "file.py:8:\x1b[31;1m error: \x1b[0mContains  [braces]  but not an error code\n",
+            "file.py:8:\x1b[31;1m error: \x1b[0mContains  [braces]  but not an error code\n\n",
             "\x1b[33;1mFixed errors: 1\n\x1b[0m",
             "\x1b[31;1mNew errors: 1\n\x1b[0m",
             "\x1b[1mTotal errors: 2\n\x1b[0m",
@@ -436,7 +430,7 @@ class TestColorChangeReportWriter:
         )
 
         assert messages == [
-            "file.py:8:\x1b[31;1m error: \x1b[0mResembles error code but  [is-not-closed\n",
+            "file.py:8:\x1b[31;1m error: \x1b[0mResembles error code but  [is-not-closed\n\n",
             "\x1b[33;1mFixed errors: 1\n\x1b[0m",
             "\x1b[31;1mNew errors: 1\n\x1b[0m",
             "\x1b[1mTotal errors: 2\n\x1b[0m",
@@ -456,7 +450,7 @@ class TestColorChangeReportWriter:
         )
 
         assert messages == [
-            "file.py:8:\x1b[31;1m error: \x1b[0mAn example type error\x1b[33m  [error-code]\x1b[0m\n",
+            "file.py:8:\x1b[31;1m error: \x1b[0mAn example type error\x1b[33m  [error-code]\x1b[0m\n\n",
             "\x1b[32mFixed errors: 0\n\x1b[0m",
             "\x1b[31;1mNew errors: 1\n\x1b[0m",
             "\x1b[1mTotal errors: 2\n\x1b[0m",
@@ -476,7 +470,7 @@ class TestColorChangeReportWriter:
         )
 
         assert messages == [
-            "file.py:8:\x1b[34m note: \x1b[0mAn example note\n",
+            "file.py:8:\x1b[34m note: \x1b[0mAn example note\n\n",
             "\x1b[33;1mFixed errors: 1\n\x1b[0m",
             "\x1b[31;1mNew errors: 1\n\x1b[0m",
             "\x1b[1mTotal errors: 2\n\x1b[0m",

--- a/tox.ini
+++ b/tox.ini
@@ -38,4 +38,4 @@ allowlist_externals =
 commands_pre =
     poetry install
 commands =
-    poetry run bash -c "mypy . --strict | mypy-json-report parse --output-file known-mypy-errors.json --diff-old-report known-mypy-errors.json"
+    poetry run bash -c "mypy . --strict | mypy-json-report parse --color --output-file known-mypy-errors.json --diff-old-report known-mypy-errors.json"


### PR DESCRIPTION
With this new `--color` (or `--colour`, or `-c`) flag, the error report can now be printed in colour.

The selected colour scheme (mostly) matches that of Mypy. (I didn't bother adding URL highlighting in notes. Please let me know if you want this.)

I used ANSI colour codes for this to avoid adding a dependency, but please let me know if you would prefer this to make use of a library such as `rich` or `colorist`.

![image](https://github.com/Memrise/mypy-json-report/assets/767671/0be00216-b41d-4232-883d-f7db2341a3f8)
![image](https://github.com/Memrise/mypy-json-report/assets/767671/8fb61082-99fb-43c6-b26a-00c46a9dbfe2)
![image](https://github.com/Memrise/mypy-json-report/assets/767671/d19de9c0-9466-42ef-bd57-ad496a80193a)
![image](https://github.com/Memrise/mypy-json-report/assets/767671/212b5b2b-e6b3-4644-a6c3-13f5f205d24c)


Happy New Year!