### PR TITLE
Handle mypy errors that don't mention a line number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-dist
+dist/
 .tox/
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Restructure project to use sub-packages, rather than putting all code in one module.
+- Added explicit output in case mypy outputs an error referencing a specific file but doesn't include a line number.
 
 ## v1.1.0 [2024-01-03]
 

--- a/mypy_json_report/parse.py
+++ b/mypy_json_report/parse.py
@@ -68,7 +68,7 @@ def parse_message_lines(
     return ExitCode.SUCCESS
 
 
-class ParseError(Exception):
+class SkipLineError(Exception):
     pass
 
 
@@ -86,7 +86,7 @@ class MypyMessage:
         for line in lines:
             try:
                 yield MypyMessage.from_line(line)
-            except ParseError:
+            except SkipLineError:
                 continue
 
     @classmethod
@@ -96,7 +96,7 @@ class MypyMessage:
         except ValueError as e:
             # Expected to happen on summary lines.
             # We could avoid this by requiring --no-error-summary
-            raise ParseError from e
+            raise SkipLineError from e
         filename, line_number, *_ = location.split(":")
         return MypyMessage(
             filename=filename,

--- a/tests/test_parse_command.py
+++ b/tests/test_parse_command.py
@@ -10,6 +10,7 @@ from mypy_json_report.parse import (
     DefaultChangeReportWriter,
     DiffReport,
     ErrorCounter,
+    FilenameWithoutLineNumberError,
     MypyMessage,
     SkipLineError,
 )
@@ -59,6 +60,12 @@ class TestMypyMessageFromLine:
         line = "Found 2 errors in 1 file (checked 3 source files)\n"
 
         with pytest.raises(SkipLineError):
+            MypyMessage.from_line(line)
+
+    def test_file_level_error(self) -> None:
+        line = "test.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info"
+
+        with pytest.raises(FilenameWithoutLineNumberError):
             MypyMessage.from_line(line)
 
     def test_multiple_lines(self) -> None:

--- a/tests/test_parse_command.py
+++ b/tests/test_parse_command.py
@@ -11,7 +11,7 @@ from mypy_json_report.parse import (
     DiffReport,
     ErrorCounter,
     MypyMessage,
-    ParseError,
+    SkipLineError,
 )
 
 
@@ -58,7 +58,7 @@ class TestMypyMessageFromLine:
     def test_summary_line(self) -> None:
         line = "Found 2 errors in 1 file (checked 3 source files)\n"
 
-        with pytest.raises(ParseError):
+        with pytest.raises(SkipLineError):
             MypyMessage.from_line(line)
 
     def test_multiple_lines(self) -> None:


### PR DESCRIPTION
This is done by stopping the parsing entirely and letting the user know why so they can investigate and hopefully fix the error first.

Errors that mention a filename but no specific line are normally indicators of a big issue which we don't have a strategy for handling right now.

Fixes #105.