### PR TITLE
Don't use dependency cache when releasing new versions

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-          cache: poetry
 
       - name: Install dependencies
         run: poetry install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.9.0
     hooks:
       - id: ruff
         args:
@@ -17,6 +17,6 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v0.8.0
+    rev: v1.0.1
     hooks:
       - id: zizmor


### PR DESCRIPTION
This is a potential risk if the cache has been poisoned by an earlier workflow.

This was caught by the latest Zizmor version which this also upgrades us to.