### PR TITLE
Use Poetry 1.x for now until the breaking changes have been addressed

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -18,7 +18,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Poetry
-        run: pipx install poetry
+        # Don't use Poetry 2 for now.
+        # It has breaking changes for how package metadata is defined.
+        run: pipx install "poetry < 2"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Poetry
-        run: pipx install poetry
+        # Don't use Poetry 2 for now.
+        # It has breaking changes for how package metadata is defined.
+        run: pipx install "poetry < 2"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Poetry 2 has new expectations about how the package metadata should be defined, which will need to be addressed before the latest Poetry version can be used: https://python-poetry.org/blog/announcing-poetry-2.0.0/.